### PR TITLE
chore: resolve lint warnings and harden null-safety

### DIFF
--- a/src/commands/advanced/apply.ts
+++ b/src/commands/advanced/apply.ts
@@ -2,7 +2,7 @@
  * advanced apply command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import {
   applyMcpInstallWithPolicy,
   selectProvidersByMinimumPriority,

--- a/src/commands/advanced/batch.ts
+++ b/src/commands/advanced/batch.ts
@@ -2,7 +2,7 @@
  * advanced batch command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { installBatchWithRollback, selectProvidersByMinimumPriority } from "../../core/advanced/orchestration.js";
 import { parsePriority, readMcpOperations, readSkillOperations, resolveProviders } from "./common.js";
 import { LAFSCommandError, runLafsCommand } from "./lafs.js";

--- a/src/commands/advanced/common.ts
+++ b/src/commands/advanced/common.ts
@@ -93,9 +93,9 @@ export async function readMcpOperations(path: string): Promise<McpBatchOperation
     }
 
     const obj = item as Record<string, unknown>;
-    const serverName = obj["serverName"];
-    const config = obj["config"];
-    const scope = obj["scope"];
+    const serverName = obj.serverName;
+    const config = obj.config;
+    const scope = obj.scope;
 
     if (typeof serverName !== "string" || serverName.length === 0) {
       throw new LAFSCommandError(
@@ -152,9 +152,9 @@ export async function readSkillOperations(path: string): Promise<SkillBatchOpera
     }
 
     const obj = item as Record<string, unknown>;
-    const sourcePath = obj["sourcePath"];
-    const skillName = obj["skillName"];
-    const isGlobal = obj["isGlobal"];
+    const sourcePath = obj.sourcePath;
+    const skillName = obj.skillName;
+    const isGlobal = obj.isGlobal;
 
     if (typeof sourcePath !== "string" || sourcePath.length === 0) {
       throw new LAFSCommandError(

--- a/src/commands/advanced/configure.ts
+++ b/src/commands/advanced/configure.ts
@@ -2,7 +2,7 @@
  * advanced configure command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { configureProviderGlobalAndProject } from "../../core/advanced/orchestration.js";
 import { getProvider } from "../../core/registry/providers.js";
 import { readMcpOperations, readTextInput } from "./common.js";

--- a/src/commands/advanced/conflicts.ts
+++ b/src/commands/advanced/conflicts.ts
@@ -2,7 +2,7 @@
  * advanced conflicts command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { detectMcpConfigConflicts, selectProvidersByMinimumPriority } from "../../core/advanced/orchestration.js";
 import { parsePriority, readMcpOperations, resolveProviders } from "./common.js";
 import { LAFSCommandError, runLafsCommand } from "./lafs.js";

--- a/src/commands/advanced/index.ts
+++ b/src/commands/advanced/index.ts
@@ -2,7 +2,7 @@
  * Advanced command group registration.
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { registerAdvancedProviders } from "./providers.js";
 import { registerAdvancedBatch } from "./batch.js";
 import { registerAdvancedConflicts } from "./conflicts.js";

--- a/src/commands/advanced/instructions.ts
+++ b/src/commands/advanced/instructions.ts
@@ -2,7 +2,7 @@
  * advanced instructions command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import {
   selectProvidersByMinimumPriority,
   updateInstructionsSingleOperation,

--- a/src/commands/advanced/providers.ts
+++ b/src/commands/advanced/providers.ts
@@ -2,7 +2,7 @@
  * advanced providers command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { selectProvidersByMinimumPriority } from "../../core/advanced/orchestration.js";
 import { parsePriority, resolveProviders } from "./common.js";
 import { runLafsCommand } from "./lafs.js";

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -2,7 +2,7 @@
  * config show|path commands
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { getProvider } from "../core/registry/providers.js";
 import { existsSync } from "node:fs";

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -2,17 +2,16 @@
  * doctor command - diagnose configuration issues and health
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { execFileSync } from "node:child_process";
-import { existsSync, readdirSync, lstatSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, lstatSync, } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { getAllProviders, getProviderCount } from "../core/registry/providers.js";
 import { detectAllProviders } from "../core/registry/detection.js";
 import { readLockFile } from "../core/mcp/lock.js";
 import { readConfig } from "../core/formats/index.js";
-import type { Provider } from "../types.js";
 
 const CAAMP_VERSION = "0.2.0";
 
@@ -187,7 +186,7 @@ async function checkLockFile(): Promise<SectionResult> {
 
     // Check for orphaned skill entries (canonical path no longer exists)
     let orphaned = 0;
-    for (const [name, entry] of Object.entries(lock.skills)) {
+    for (const [_name, entry] of Object.entries(lock.skills)) {
       if (entry.canonicalPath && !existsSync(entry.canonicalPath)) {
         orphaned++;
       }

--- a/src/commands/instructions/check.ts
+++ b/src/commands/instructions/check.ts
@@ -2,7 +2,7 @@
  * instructions check command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { checkAllInjections } from "../../core/instructions/injector.js";
 import { getInstalledProviders } from "../../core/registry/detection.js";

--- a/src/commands/instructions/index.ts
+++ b/src/commands/instructions/index.ts
@@ -2,7 +2,7 @@
  * Instructions command group registration
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { registerInstructionsInject } from "./inject.js";
 import { registerInstructionsCheck } from "./check.js";
 import { registerInstructionsUpdate } from "./update.js";

--- a/src/commands/instructions/inject.ts
+++ b/src/commands/instructions/inject.ts
@@ -2,7 +2,7 @@
  * instructions inject command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { injectAll } from "../../core/instructions/injector.js";
 import { generateInjectionContent, groupByInstructFile } from "../../core/instructions/templates.js";

--- a/src/commands/instructions/update.ts
+++ b/src/commands/instructions/update.ts
@@ -2,12 +2,11 @@
  * instructions update command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
-import { injectAll, checkAllInjections } from "../../core/instructions/injector.js";
+import { checkAllInjections, injectAll } from "../../core/instructions/injector.js";
 import { generateInjectionContent } from "../../core/instructions/templates.js";
 import { getInstalledProviders } from "../../core/registry/detection.js";
-import type { Provider } from "../../types.js";
 
 export function registerInstructionsUpdate(parent: Command): void {
   parent

--- a/src/commands/mcp/detect.ts
+++ b/src/commands/mcp/detect.ts
@@ -2,7 +2,7 @@
  * mcp detect command - auto-detect installed MCP tools
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { existsSync } from "node:fs";
 import { getInstalledProviders } from "../../core/registry/detection.js";

--- a/src/commands/mcp/index.ts
+++ b/src/commands/mcp/index.ts
@@ -2,7 +2,7 @@
  * MCP command group registration
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { registerMcpInstall } from "./install.js";
 import { registerMcpRemove } from "./remove.js";
 import { registerMcpList } from "./list.js";

--- a/src/commands/mcp/install.ts
+++ b/src/commands/mcp/install.ts
@@ -2,7 +2,7 @@
  * mcp install command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { parseSource } from "../../core/sources/parser.js";
 import { installMcpServerToAll, buildServerConfig } from "../../core/mcp/installer.js";

--- a/src/commands/mcp/list.ts
+++ b/src/commands/mcp/list.ts
@@ -2,7 +2,7 @@
  * mcp list command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { getInstalledProviders } from "../../core/registry/detection.js";
 import { getProvider } from "../../core/registry/providers.js";

--- a/src/commands/mcp/remove.ts
+++ b/src/commands/mcp/remove.ts
@@ -2,7 +2,7 @@
  * mcp remove command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { getInstalledProviders } from "../../core/registry/detection.js";
 import { getProvider } from "../../core/registry/providers.js";

--- a/src/commands/providers.ts
+++ b/src/commands/providers.ts
@@ -2,7 +2,7 @@
  * providers list|detect|show commands
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import {
   getAllProviders,

--- a/src/commands/skills/audit.ts
+++ b/src/commands/skills/audit.ts
@@ -2,10 +2,11 @@
  * skills audit command - security scanning
  */
 
-import { Command } from "commander";
-import pc from "picocolors";
-import { scanFile, scanDirectory, toSarif } from "../../core/skills/audit/scanner.js";
 import { existsSync, statSync } from "node:fs";
+import type { Command } from "commander";
+import pc from "picocolors";
+import { scanDirectory, scanFile, toSarif } from "../../core/skills/audit/scanner.js";
+import type { AuditResult } from "../../types.js";
 
 export function registerSkillsAudit(parent: Command): void {
   parent
@@ -21,7 +22,7 @@ export function registerSkillsAudit(parent: Command): void {
       }
 
       const stat = statSync(path);
-      let results;
+      let results: AuditResult[];
 
       if (stat.isFile()) {
         results = [await scanFile(path)];

--- a/src/commands/skills/check.ts
+++ b/src/commands/skills/check.ts
@@ -2,7 +2,7 @@
  * skills check command - check for updates
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { getTrackedSkills, checkSkillUpdate } from "../../core/skills/lock.js";
 

--- a/src/commands/skills/find.ts
+++ b/src/commands/skills/find.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { Command } from "commander";
+import type { Command } from "commander";
 import {
   resolveOutputFormat,
   type LAFSErrorCategory,

--- a/src/commands/skills/index.ts
+++ b/src/commands/skills/index.ts
@@ -2,7 +2,7 @@
  * Skills command group registration
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { registerSkillsInstall } from "./install.js";
 import { registerSkillsRemove } from "./remove.js";
 import { registerSkillsList } from "./list.js";

--- a/src/commands/skills/init.ts
+++ b/src/commands/skills/init.ts
@@ -2,7 +2,7 @@
  * skills init command - scaffold a new skill
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { writeFile, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
@@ -54,7 +54,7 @@ Show example inputs and expected outputs.
       console.log(pc.green(`✓ Created skill template: ${skillDir}/SKILL.md`));
       console.log(pc.dim("\nNext steps:"));
       console.log(pc.dim("  1. Edit SKILL.md with your instructions"));
-      console.log(pc.dim("  2. Validate: caamp skills validate " + join(skillDir, "SKILL.md")));
-      console.log(pc.dim("  3. Install: caamp skills install " + skillDir));
+      console.log(pc.dim(`  2. Validate: caamp skills validate ${join(skillDir, "SKILL.md")}`));
+      console.log(pc.dim(`  3. Install: caamp skills install ${skillDir}`));
     });
 }

--- a/src/commands/skills/install.ts
+++ b/src/commands/skills/install.ts
@@ -2,7 +2,7 @@
  * skills install command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import { existsSync } from "node:fs";
 import pc from "picocolors";
 import { parseSource, isMarketplaceScoped } from "../../core/sources/parser.js";

--- a/src/commands/skills/list.ts
+++ b/src/commands/skills/list.ts
@@ -2,10 +2,9 @@
  * skills list command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
-import { discoverSkills, discoverSkillsMulti } from "../../core/skills/discovery.js";
-import { listCanonicalSkills } from "../../core/skills/installer.js";
+import { discoverSkillsMulti } from "../../core/skills/discovery.js";
 import { getProvider } from "../../core/registry/providers.js";
 import { getInstalledProviders } from "../../core/registry/detection.js";
 import { resolveProviderSkillsDir } from "../../core/paths/standard.js";

--- a/src/commands/skills/remove.ts
+++ b/src/commands/skills/remove.ts
@@ -2,7 +2,7 @@
  * skills remove command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { removeSkill, listCanonicalSkills } from "../../core/skills/installer.js";
 import { removeSkillFromLock } from "../../core/skills/lock.js";

--- a/src/commands/skills/update.ts
+++ b/src/commands/skills/update.ts
@@ -2,7 +2,7 @@
  * skills update command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { getTrackedSkills, checkSkillUpdate, recordSkillInstall } from "../../core/skills/lock.js";
 import { installSkill } from "../../core/skills/installer.js";

--- a/src/commands/skills/validate.ts
+++ b/src/commands/skills/validate.ts
@@ -2,7 +2,7 @@
  * skills validate command
  */
 
-import { Command } from "commander";
+import type { Command } from "commander";
 import pc from "picocolors";
 import { validateSkill } from "../../core/skills/validator.js";
 

--- a/src/core/formats/json.ts
+++ b/src/core/formats/json.ts
@@ -8,7 +8,7 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import * as jsonc from "jsonc-parser";
-import { deepMerge, setNestedValue, ensureDir } from "./utils.js";
+import { ensureDir } from "./utils.js";
 
 /** Read a JSON/JSONC config file */
 export async function readJsonConfig(filePath: string): Promise<Record<string, unknown>> {

--- a/src/core/formats/toml.ts
+++ b/src/core/formats/toml.ts
@@ -2,8 +2,8 @@
  * TOML config reader/writer
  */
 
-import { readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import TOML from "@iarna/toml";
 import { deepMerge, ensureDir } from "./utils.js";
 
@@ -33,8 +33,8 @@ export async function writeTomlConfig(
   const keyParts = configKey.split(".");
   let newEntry: Record<string, unknown> = { [serverName]: serverConfig };
 
-  for (let i = keyParts.length - 1; i >= 0; i--) {
-    newEntry = { [keyParts[i]!]: newEntry };
+  for (const part of [...keyParts].reverse()) {
+    newEntry = { [part]: newEntry };
   }
 
   const merged = deepMerge(existing, newEntry);

--- a/src/core/formats/utils.ts
+++ b/src/core/formats/utils.ts
@@ -60,7 +60,8 @@ export function setNestedValue(
   let current: Record<string, unknown> = result;
 
   for (let i = 0; i < parts.length; i++) {
-    const part = parts[i]!;
+    const part = parts[i];
+    if (part === undefined) continue;
     if (i === parts.length - 1) {
       // Last part: set the server entry
       const existing = (current[part] as Record<string, unknown>) ?? {};

--- a/src/core/formats/yaml.ts
+++ b/src/core/formats/yaml.ts
@@ -2,8 +2,8 @@
  * YAML config reader/writer
  */
 
-import { readFile, writeFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
+import { readFile, writeFile } from "node:fs/promises";
 import yaml from "js-yaml";
 import { deepMerge, ensureDir } from "./utils.js";
 
@@ -33,8 +33,8 @@ export async function writeYamlConfig(
   const keyParts = configKey.split(".");
   let newEntry: Record<string, unknown> = { [serverName]: serverConfig };
 
-  for (let i = keyParts.length - 1; i >= 0; i--) {
-    newEntry = { [keyParts[i]!]: newEntry };
+  for (const part of [...keyParts].reverse()) {
+    newEntry = { [part]: newEntry };
   }
 
   const merged = deepMerge(existing, newEntry);

--- a/src/core/instructions/injector.ts
+++ b/src/core/instructions/injector.ts
@@ -102,7 +102,7 @@ export async function inject(
 
   if (!existsSync(filePath)) {
     // Create new file with injection block
-    await writeFile(filePath, block + "\n", "utf-8");
+    await writeFile(filePath, `${block}\n`, "utf-8");
     return "created";
   }
 
@@ -116,7 +116,7 @@ export async function inject(
   }
 
   // Prepend block to existing content
-  const updated = block + "\n\n" + existing;
+  const updated = `${block}\n\n${existing}`;
   await writeFile(filePath, updated, "utf-8");
   return "added";
 }
@@ -150,7 +150,7 @@ export async function removeInjection(filePath: string): Promise<boolean> {
     const { rm } = await import("node:fs/promises");
     await rm(filePath);
   } else {
-    await writeFile(filePath, cleaned + "\n", "utf-8");
+    await writeFile(filePath, `${cleaned}\n`, "utf-8");
   }
 
   return true;

--- a/src/core/lock-utils.ts
+++ b/src/core/lock-utils.ts
@@ -41,7 +41,7 @@ async function releaseLockGuard(): Promise<void> {
 
 async function writeLockFileUnsafe(lock: CaampLockFile): Promise<void> {
   const tmpPath = `${LOCK_FILE_PATH}.tmp-${process.pid}-${Date.now()}`;
-  await writeFile(tmpPath, JSON.stringify(lock, null, 2) + "\n", "utf-8");
+  await writeFile(tmpPath, `${JSON.stringify(lock, null, 2)}\n`, "utf-8");
   await rename(tmpPath, LOCK_FILE_PATH);
 }
 

--- a/src/core/marketplace/skillsmp.ts
+++ b/src/core/marketplace/skillsmp.ts
@@ -5,8 +5,8 @@
  * GitHub is always the actual source for installation.
  */
 
-import type { MarketplaceAdapter, MarketplaceResult, SearchOptions } from "./types.js";
 import { ensureOkResponse, fetchWithTimeout } from "../network/fetch.js";
+import type { MarketplaceAdapter, MarketplaceResult, } from "./types.js";
 
 const API_BASE = "https://www.agentskills.in/api/skills";
 
@@ -40,9 +40,11 @@ interface ScopedNameParts {
 function parseScopedName(value: string): ScopedNameParts | null {
   const match = value.match(/^@([^/]+)\/([^/]+)$/);
   if (!match) return null;
+  const [, author, name] = match;
+  if (!author || !name) return null;
   return {
-    author: match[1]!,
-    name: match[2]!,
+    author,
+    name,
   };
 }
 

--- a/src/core/mcp/installer.ts
+++ b/src/core/mcp/installer.ts
@@ -5,11 +5,11 @@
  * handling per-agent formats, keys, and transformations.
  */
 
-import type { Provider, McpServerConfig, GlobalOptions } from "../../types.js";
+import type { McpServerConfig, Provider, } from "../../types.js";
 import { writeConfig } from "../formats/index.js";
-import { getTransform } from "./transforms.js";
-import { resolveConfigPath } from "./reader.js";
 import { debug } from "../logger.js";
+import { resolveConfigPath } from "./reader.js";
+import { getTransform } from "./transforms.js";
 
 /**
  * Result of installing an MCP server configuration to a single provider.
@@ -197,9 +197,10 @@ export function buildServerConfig(
   }
 
   // Command type - split into command and args
-  const parts = source.value.split(/\s+/);
+  const parts = source.value.trim().split(/\s+/);
+  const command = parts[0] ?? source.value;
   return {
-    command: parts[0]!,
+    command,
     args: parts.slice(1),
   };
 }

--- a/src/core/mcp/transforms.ts
+++ b/src/core/mcp/transforms.ts
@@ -35,7 +35,7 @@ export function transformGoose(serverName: string, config: McpServerConfig): unk
 }
 
 /** Transform config for Zed (context_servers format) */
-export function transformZed(serverName: string, config: McpServerConfig): unknown {
+export function transformZed(_serverName: string, config: McpServerConfig): unknown {
   if (config.url) {
     return {
       source: "custom",
@@ -54,7 +54,7 @@ export function transformZed(serverName: string, config: McpServerConfig): unkno
 }
 
 /** Transform config for OpenCode (mcp format) */
-export function transformOpenCode(serverName: string, config: McpServerConfig): unknown {
+export function transformOpenCode(_serverName: string, config: McpServerConfig): unknown {
   if (config.url) {
     return {
       type: "remote",
@@ -74,7 +74,7 @@ export function transformOpenCode(serverName: string, config: McpServerConfig): 
 }
 
 /** Transform config for Codex (TOML mcp_servers format) */
-export function transformCodex(serverName: string, config: McpServerConfig): unknown {
+export function transformCodex(_serverName: string, config: McpServerConfig): unknown {
   if (config.url) {
     return {
       type: config.type ?? "http",
@@ -91,7 +91,7 @@ export function transformCodex(serverName: string, config: McpServerConfig): unk
 }
 
 /** Transform config for Cursor (mcpServers format - strips type field for remote) */
-export function transformCursor(serverName: string, config: McpServerConfig): unknown {
+export function transformCursor(_serverName: string, config: McpServerConfig): unknown {
   if (config.url) {
     return {
       url: config.url,

--- a/src/core/paths/standard.ts
+++ b/src/core/paths/standard.ts
@@ -19,7 +19,7 @@ export function getPlatformLocations(): PlatformLocations {
   const platform = process.platform;
 
   if (platform === "win32") {
-    const appData = process.env["APPDATA"] ?? join(home, "AppData", "Roaming");
+    const appData = process.env.APPDATA ?? join(home, "AppData", "Roaming");
     return {
       home,
       config: appData,
@@ -31,7 +31,7 @@ export function getPlatformLocations(): PlatformLocations {
   }
 
   if (platform === "darwin") {
-    const config = process.env["XDG_CONFIG_HOME"] ?? join(home, ".config");
+    const config = process.env.XDG_CONFIG_HOME ?? join(home, ".config");
     return {
       home,
       config,
@@ -42,7 +42,7 @@ export function getPlatformLocations(): PlatformLocations {
     };
   }
 
-  const config = process.env["XDG_CONFIG_HOME"] ?? join(home, ".config");
+  const config = process.env.XDG_CONFIG_HOME ?? join(home, ".config");
   return {
     home,
     config,
@@ -69,7 +69,7 @@ function normalizeHomeOverride(value: string): string {
 }
 
 export function getAgentsHome(): string {
-  const override = process.env["AGENTS_HOME"];
+  const override = process.env.AGENTS_HOME;
   if (override && override.trim().length > 0) {
     return normalizeHomeOverride(override);
   }

--- a/src/core/registry/providers.ts
+++ b/src/core/registry/providers.ts
@@ -8,9 +8,9 @@
 import { readFileSync } from "node:fs";
 import { dirname } from "node:path";
 import { fileURLToPath } from "node:url";
-import type { Provider, ConfigFormat, TransportType, ProviderPriority, ProviderStatus, DetectionMethod } from "../../types.js";
-import type { ProviderRegistry, RegistryProvider } from "./types.js";
+import type { ConfigFormat, DetectionMethod, Provider, ProviderPriority, ProviderStatus, TransportType } from "../../types.js";
 import { resolveProvidersRegistryPath, resolveRegistryTemplatePath } from "../paths/standard.js";
+import type { ProviderRegistry, RegistryProvider } from "./types.js";
 
 function findRegistryPath(): string {
   const thisDir = dirname(fileURLToPath(import.meta.url));
@@ -95,7 +95,8 @@ function ensureProviders(): void {
  */
 export function getAllProviders(): Provider[] {
   ensureProviders();
-  return Array.from(_providers!.values());
+  if (!_providers) return [];
+  return Array.from(_providers.values());
 }
 
 /**
@@ -112,8 +113,8 @@ export function getAllProviders(): Provider[] {
  */
 export function getProvider(idOrAlias: string): Provider | undefined {
   ensureProviders();
-  const resolved = _aliasMap!.get(idOrAlias) ?? idOrAlias;
-  return _providers!.get(resolved);
+  const resolved = _aliasMap?.get(idOrAlias) ?? idOrAlias;
+  return _providers?.get(resolved);
 }
 
 /**
@@ -133,7 +134,7 @@ export function getProvider(idOrAlias: string): Provider | undefined {
  */
 export function resolveAlias(idOrAlias: string): string {
   ensureProviders();
-  return _aliasMap!.get(idOrAlias) ?? idOrAlias;
+  return _aliasMap?.get(idOrAlias) ?? idOrAlias;
 }
 
 /**
@@ -214,7 +215,7 @@ export function getInstructionFiles(): string[] {
  */
 export function getProviderCount(): number {
   ensureProviders();
-  return _providers!.size;
+  return _providers?.size ?? 0;
 }
 
 /**

--- a/src/core/skills/audit/rules.ts
+++ b/src/core/skills/audit/rules.ts
@@ -35,7 +35,7 @@ export const AUDIT_RULES: AuditRule[] = [
   rule("PI007", "Context manipulation", "Fake conversation context", "high", "prompt-injection",
     /(?:Human:|Assistant:|User:|System:)\s*(?:ignore|execute|run)/i),
   rule("PI008", "Token smuggling", "Invisible characters or zero-width spaces", "medium", "prompt-injection",
-    /[\u200B\u200C\u200D\u2060\uFEFF]/),
+    /(?:\u200B|\u200C|\u200D|\u2060|\uFEFF)/),
 
   // ── Command Injection ───────────────────────────────────────
   rule("CI001", "Destructive command", "File deletion or system modification", "critical", "command-injection",

--- a/src/core/skills/audit/scanner.ts
+++ b/src/core/skills/audit/scanner.ts
@@ -5,9 +5,9 @@
  * and produces findings with line-level precision.
  */
 
-import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import type { AuditResult, AuditFinding, AuditRule, AuditSeverity } from "../../../types.js";
+import { readFile } from "node:fs/promises";
+import type { AuditFinding, AuditResult, AuditRule, AuditSeverity } from "../../../types.js";
 import { AUDIT_RULES } from "./rules.js";
 
 const SEVERITY_WEIGHTS: Record<AuditSeverity, number> = {
@@ -50,7 +50,7 @@ export async function scanFile(
 
   for (const rule of activeRules) {
     for (let i = 0; i < lines.length; i++) {
-      const line = lines[i]!;
+      const line = lines[i] ?? "";
       const match = line.match(rule.pattern);
       if (match) {
         findings.push({

--- a/src/core/skills/discovery.ts
+++ b/src/core/skills/discovery.ts
@@ -6,7 +6,7 @@
 
 import { readFile, readdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
-import { join, dirname, basename } from "node:path";
+import { join, } from "node:path";
 import matter from "gray-matter";
 import type { SkillEntry, SkillMetadata } from "../../types.js";
 
@@ -33,24 +33,24 @@ export async function parseSkillFile(filePath: string): Promise<SkillMetadata | 
     const content = await readFile(filePath, "utf-8");
     const { data } = matter(content);
 
-    if (!data["name"] || !data["description"]) {
+    if (!data.name || !data.description) {
       return null;
     }
 
-    const allowedTools = data["allowed-tools"] ?? data["allowedTools"];
+    const allowedTools = data["allowed-tools"] ?? data.allowedTools;
 
     return {
-      name: String(data["name"]),
-      description: String(data["description"]),
-      license: data["license"] ? String(data["license"]) : undefined,
-      compatibility: data["compatibility"] ? String(data["compatibility"]) : undefined,
-      metadata: data["metadata"] as Record<string, string> | undefined,
+      name: String(data.name),
+      description: String(data.description),
+      license: data.license ? String(data.license) : undefined,
+      compatibility: data.compatibility ? String(data.compatibility) : undefined,
+      metadata: data.metadata as Record<string, string> | undefined,
       allowedTools: typeof allowedTools === "string"
         ? allowedTools.split(/\s+/)
         : Array.isArray(allowedTools)
           ? allowedTools.map(String)
           : undefined,
-      version: data["version"] ? String(data["version"]) : undefined,
+      version: data.version ? String(data.version) : undefined,
     };
   } catch {
     return null;

--- a/src/core/skills/installer.ts
+++ b/src/core/skills/installer.ts
@@ -5,11 +5,10 @@
  * and symlinked to each target agent's skills directory.
  */
 
-import { readFile, writeFile, mkdir, symlink, readlink, rm, cp } from "node:fs/promises";
+import { mkdir, symlink, rm, cp } from "node:fs/promises";
 import { existsSync, lstatSync } from "node:fs";
-import { join, relative, resolve } from "node:path";
-import type { Provider, SkillMetadata, ParsedSource } from "../../types.js";
-import { discoverSkill } from "./discovery.js";
+import { join, } from "node:path";
+import type { Provider, } from "../../types.js";
 import { CANONICAL_SKILLS_DIR } from "../paths/agents.js";
 import { resolveProviderSkillsDir } from "../paths/standard.js";
 

--- a/src/core/skills/validator.ts
+++ b/src/core/skills/validator.ts
@@ -118,10 +118,10 @@ export async function validateSkill(filePath: string): Promise<ValidationResult>
   }
 
   // Required: name
-  if (!data["name"]) {
+  if (!data.name) {
     issues.push({ level: "error", field: "name", message: "Missing required field: name" });
   } else {
-    const name = String(data["name"]);
+    const name = String(data.name);
 
     if (name.length > MAX_NAME_LENGTH) {
       issues.push({
@@ -157,10 +157,10 @@ export async function validateSkill(filePath: string): Promise<ValidationResult>
   }
 
   // Required: description
-  if (!data["description"]) {
+  if (!data.description) {
     issues.push({ level: "error", field: "description", message: "Missing required field: description" });
   } else {
-    const desc = String(data["description"]);
+    const desc = String(data.description);
 
     if (desc.length > MAX_DESCRIPTION_LENGTH) {
       issues.push({

--- a/src/core/sources/github.ts
+++ b/src/core/sources/github.ts
@@ -8,7 +8,6 @@ import { simpleGit } from "simple-git";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { existsSync } from "node:fs";
 
 export interface GitFetchResult {
   localPath: string;

--- a/tests/unit/advanced-orchestration.test.ts
+++ b/tests/unit/advanced-orchestration.test.ts
@@ -149,8 +149,8 @@ describe("updateInstructionsSingleOperation", () => {
     );
 
     expect(result.updatedFiles).toBe(1);
-    expect(result.actions[0]!.providers.sort()).toEqual(["p1", "p2"]);
-    expect(result.actions[0]!.configFormats.sort()).toEqual(["json", "yaml"]);
+    expect(result.actions[0]?.providers.sort()).toEqual(["p1", "p2"]);
+    expect(result.actions[0]?.configFormats.sort()).toEqual(["json", "yaml"]);
   });
 });
 
@@ -168,8 +168,8 @@ describe("configureProviderGlobalAndProject", () => {
       projectDir: testDir,
     });
 
-    expect(result.mcp.global[0]!.success).toBe(true);
-    expect(result.mcp.project[0]!.success).toBe(true);
+    expect(result.mcp.global[0]?.success).toBe(true);
+    expect(result.mcp.project[0]?.success).toBe(true);
 
     const globalInstructionPath = join(provider.pathGlobal, provider.instructFile);
     const projectInstructionPath = join(testDir, provider.instructFile);

--- a/tests/unit/detection.test.ts
+++ b/tests/unit/detection.test.ts
@@ -97,7 +97,7 @@ describe("detection engine", () => {
   });
 
   it("detects all providers and installed providers", () => {
-    mocks.execFileSync.mockImplementation((cmd: string, args: string[]) => {
+    mocks.execFileSync.mockImplementation((_cmd: string, args: string[]) => {
       if (args[0] === "installed") return "ok";
       throw new Error("missing");
     });

--- a/tests/unit/formats.test.ts
+++ b/tests/unit/formats.test.ts
@@ -153,7 +153,7 @@ describe("YAML Format", () => {
     });
 
     const data = await readYamlConfig(filePath);
-    expect((data.extensions as Record<string, unknown>)?.["test"]).toBeDefined();
+    expect((data.extensions as Record<string, unknown>)?.test).toBeDefined();
   });
 
   it("returns empty object for missing file", async () => {

--- a/tests/unit/installer.test.ts
+++ b/tests/unit/installer.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { rm, mkdir, writeFile, readFile } from "node:fs/promises";
-import { existsSync, lstatSync } from "node:fs";
+import { rm, mkdir, writeFile, } from "node:fs/promises";
+import { existsSync, } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { installToCanonical, listCanonicalSkills } from "../../src/core/skills/installer.js";
+import { installToCanonical, } from "../../src/core/skills/installer.js";
 import { validateSkill } from "../../src/core/skills/validator.js";
 
 let testDir: string;

--- a/tests/unit/instructions.test.ts
+++ b/tests/unit/instructions.test.ts
@@ -212,8 +212,8 @@ describe("checkAllInjections()", () => {
     const results = await checkAllInjections(providers, testDir, "project");
     // Should deduplicate - only one result for CLAUDE.md
     expect(results).toHaveLength(1);
-    expect(results[0]!.status).toBe("current");
-    expect(results[0]!.fileExists).toBe(true);
+    expect(results[0]?.status).toBe("current");
+    expect(results[0]?.fileExists).toBe(true);
   });
 
   it("returns results for different instruction files", async () => {
@@ -230,8 +230,8 @@ describe("checkAllInjections()", () => {
 
     const claudeResult = results.find((r) => r.file.includes("CLAUDE.md"));
     const agentsResult = results.find((r) => r.file.includes("AGENTS.md"));
-    expect(claudeResult!.status).toBe("current");
-    expect(agentsResult!.status).toBe("missing");
+    expect(claudeResult?.status).toBe("current");
+    expect(agentsResult?.status).toBe("missing");
   });
 });
 

--- a/tests/unit/lock.test.ts
+++ b/tests/unit/lock.test.ts
@@ -1,7 +1,5 @@
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { describe, expect, it, } from "vitest";
 
 // We test the lock file data structures and utility functions
 // rather than the file I/O functions that depend on specific paths

--- a/tests/unit/marketplace.test.ts
+++ b/tests/unit/marketplace.test.ts
@@ -65,8 +65,8 @@ describe("MarketplaceClient", () => {
     const results = await client.search("test");
     expect(results).toHaveLength(2);
     // Sorted by stars descending
-    expect(results[0]!.scopedName).toBe("@b/skill2");
-    expect(results[1]!.scopedName).toBe("@a/skill1");
+    expect(results[0]?.scopedName).toBe("@b/skill2");
+    expect(results[1]?.scopedName).toBe("@a/skill1");
   });
 
   it("deduplicates by scopedName keeping higher star count", async () => {
@@ -79,8 +79,8 @@ describe("MarketplaceClient", () => {
 
     const results = await client.search("dup");
     expect(results).toHaveLength(1);
-    expect(results[0]!.stars).toBe(20);
-    expect(results[0]!.source).toBe("sh");
+    expect(results[0]?.stars).toBe(20);
+    expect(results[0]?.source).toBe("sh");
   });
 
   it("handles adapter errors gracefully (returns empty for failed adapter)", async () => {
@@ -95,7 +95,7 @@ describe("MarketplaceClient", () => {
 
     const results = await client.search("test");
     expect(results).toHaveLength(1);
-    expect(results[0]!.scopedName).toBe("@a/ok");
+    expect(results[0]?.scopedName).toBe("@a/ok");
   });
 
   it("throws when all adapters fail during search", async () => {
@@ -133,7 +133,7 @@ describe("MarketplaceClient", () => {
 
     const result = await client.getSkill("@a/found");
     expect(result).not.toBeNull();
-    expect(result!.scopedName).toBe("@a/found");
+    expect(result?.scopedName).toBe("@a/found");
   });
 
   it("getSkill returns null when no adapter has the skill", async () => {
@@ -157,7 +157,7 @@ describe("MarketplaceClient", () => {
 
     const result = await client.getSkill("@a/recover");
     expect(result).not.toBeNull();
-    expect(result!.scopedName).toBe("@a/recover");
+    expect(result?.scopedName).toBe("@a/recover");
   });
 
   it("getSkill throws when all adapters fail", async () => {
@@ -191,7 +191,7 @@ describe("SkillsMPAdapter", () => {
     await adapter.search("react hooks", 5);
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
-    const url = mockFetch.mock.calls[0]![0] as string;
+    const url = mockFetch.mock.calls[0]?.[0] as string;
     expect(url).toContain("agentskills.in/api/skills");
     expect(url).toContain("search=react+hooks");
     expect(url).toContain("limit=5");
@@ -286,9 +286,9 @@ describe("SkillsMPAdapter", () => {
     const adapter = new SkillsMPAdapter();
     const result = await adapter.getSkill("@bob/target");
     expect(result).not.toBeNull();
-    expect(result!.scopedName).toBe("@bob/target");
+    expect(result?.scopedName).toBe("@bob/target");
 
-    const url = mockFetch.mock.calls[0]![0] as string;
+    const url = mockFetch.mock.calls[0]?.[0] as string;
     expect(url).toContain("search=target");
     expect(url).toContain("limit=50");
   });
@@ -330,8 +330,8 @@ describe("SkillsMPAdapter", () => {
     expect(result).not.toBeNull();
     expect(mockFetch).toHaveBeenCalledTimes(2);
 
-    const firstUrl = mockFetch.mock.calls[0]![0] as string;
-    const secondUrl = mockFetch.mock.calls[1]![0] as string;
+    const firstUrl = mockFetch.mock.calls[0]?.[0] as string;
+    const secondUrl = mockFetch.mock.calls[1]?.[0] as string;
     expect(firstUrl).toContain("search=target");
     expect(secondUrl).toContain("search=bob+target");
   });
@@ -362,7 +362,7 @@ describe("SkillsShAdapter", () => {
     const adapter = new SkillsShAdapter();
     await adapter.search("vue", 10);
 
-    const url = mockFetch.mock.calls[0]![0] as string;
+    const url = mockFetch.mock.calls[0]?.[0] as string;
     expect(url).toContain("skills.sh/api/search");
     expect(url).toContain("q=vue");
     expect(url).toContain("limit=10");
@@ -425,7 +425,7 @@ describe("SkillsShAdapter", () => {
 
     const adapter = new SkillsShAdapter();
     const results = await adapter.search("no-stars");
-    expect(results[0]!.stars).toBe(0);
+    expect(results[0]?.stars).toBe(0);
   });
 
   it("throws on non-ok response", async () => {
@@ -472,7 +472,7 @@ describe("SkillsShAdapter", () => {
     const adapter = new SkillsShAdapter();
     const result = await adapter.getSkill("@eve/exact");
     expect(result).not.toBeNull();
-    expect(result!.scopedName).toBe("@eve/exact");
+    expect(result?.scopedName).toBe("@eve/exact");
   });
 
   it("getSkill returns null when no exact match found", async () => {

--- a/tests/unit/mcp-reader.test.ts
+++ b/tests/unit/mcp-reader.test.ts
@@ -95,13 +95,13 @@ describe("listMcpServers", () => {
     const result = await listMcpServers(provider, "global");
 
     expect(result).toHaveLength(2);
-    expect(result[0]!.name).toBe("server-a");
-    expect(result[0]!.providerId).toBe("test-agent");
-    expect(result[0]!.providerName).toBe("Test Agent");
-    expect(result[0]!.scope).toBe("global");
-    expect(result[0]!.configPath).toBe(configPath);
-    expect(result[0]!.config).toEqual({ command: "npx", args: ["-y", "server-a"] });
-    expect(result[1]!.name).toBe("server-b");
+    expect(result[0]?.name).toBe("server-a");
+    expect(result[0]?.providerId).toBe("test-agent");
+    expect(result[0]?.providerName).toBe("Test Agent");
+    expect(result[0]?.scope).toBe("global");
+    expect(result[0]?.configPath).toBe(configPath);
+    expect(result[0]?.config).toEqual({ command: "npx", args: ["-y", "server-a"] });
+    expect(result[1]?.name).toBe("server-b");
   });
 
   it("returns empty array when config key has no servers", async () => {
@@ -137,7 +137,7 @@ describe("listMcpServers", () => {
     const result = await listMcpServers(provider, "global");
 
     expect(result).toHaveLength(1);
-    expect(result[0]!.name).toBe("my-server");
+    expect(result[0]?.name).toBe("my-server");
   });
 
   it("handles malformed config files gracefully", async () => {
@@ -167,8 +167,8 @@ describe("listAllMcpServers", () => {
 
     const result = await listAllMcpServers([providerA, providerB], "global");
     expect(result).toHaveLength(2);
-    expect(result[0]!.providerId).toBe("agent-a");
-    expect(result[1]!.providerId).toBe("agent-b");
+    expect(result[0]?.providerId).toBe("agent-a");
+    expect(result[1]?.providerId).toBe("agent-b");
   });
 
   it("deduplicates by config path", async () => {
@@ -183,7 +183,7 @@ describe("listAllMcpServers", () => {
     const result = await listAllMcpServers([providerA, providerB], "global");
     // Should only include entries from the first provider that claimed this config path
     expect(result).toHaveLength(1);
-    expect(result[0]!.providerId).toBe("agent-a");
+    expect(result[0]?.providerId).toBe("agent-a");
   });
 
   it("returns empty array when no providers given", async () => {
@@ -209,7 +209,7 @@ describe("removeMcpServer", () => {
     // Verify the server was removed
     const remaining = await listMcpServers(provider, "global");
     expect(remaining).toHaveLength(1);
-    expect(remaining[0]!.name).toBe("keep");
+    expect(remaining[0]?.name).toBe("keep");
   });
 
   it("returns false when server does not exist", async () => {

--- a/tests/unit/paths-standard.test.ts
+++ b/tests/unit/paths-standard.test.ts
@@ -6,19 +6,19 @@ import {
   resolveRegistryTemplatePath,
 } from "../../src/core/paths/standard.js";
 
-const originalAgentsHome = process.env["AGENTS_HOME"];
+const originalAgentsHome = process.env.AGENTS_HOME;
 
 describe("paths standard", () => {
   afterEach(() => {
     if (originalAgentsHome === undefined) {
-      delete process.env["AGENTS_HOME"];
+      delete process.env.AGENTS_HOME;
     } else {
-      process.env["AGENTS_HOME"] = originalAgentsHome;
+      process.env.AGENTS_HOME = originalAgentsHome;
     }
   });
 
   it("respects AGENTS_HOME override for canonical paths", () => {
-    process.env["AGENTS_HOME"] = "~/custom-agents";
+    process.env.AGENTS_HOME = "~/custom-agents";
 
     expect(getAgentsHome()).toContain("custom-agents");
     expect(getCanonicalSkillsDir()).toContain("custom-agents");
@@ -26,7 +26,7 @@ describe("paths standard", () => {
   });
 
   it("resolves registry template variables", () => {
-    process.env["AGENTS_HOME"] = "~/agents-override";
+    process.env.AGENTS_HOME = "~/agents-override";
     const resolved = resolveRegistryTemplatePath("$AGENTS_HOME/skills");
     expect(resolved).toContain("agents-override");
     expect(resolved).not.toContain("$AGENTS_HOME");

--- a/tests/unit/registry.test.ts
+++ b/tests/unit/registry.test.ts
@@ -1,15 +1,15 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import {
   getAllProviders,
+  getInstructionFiles,
   getProvider,
-  resolveAlias,
+  getProviderCount,
+  getProvidersByInstructFile,
   getProvidersByPriority,
   getProvidersByStatus,
-  getProvidersByInstructFile,
-  getInstructionFiles,
-  getProviderCount,
   getRegistryVersion,
   resetRegistry,
+  resolveAlias,
 } from "../../src/core/registry/providers.js";
 
 beforeEach(() => {
@@ -33,15 +33,15 @@ describe("Provider Registry", () => {
   it("gets provider by ID", () => {
     const claude = getProvider("claude-code");
     expect(claude).toBeDefined();
-    expect(claude!.toolName).toBe("Claude Code");
-    expect(claude!.vendor).toBe("Anthropic");
-    expect(claude!.instructFile).toBe("CLAUDE.md");
+    expect(claude?.toolName).toBe("Claude Code");
+    expect(claude?.vendor).toBe("Anthropic");
+    expect(claude?.instructFile).toBe("CLAUDE.md");
   });
 
   it("gets provider by alias", () => {
     const claude = getProvider("claude");
     expect(claude).toBeDefined();
-    expect(claude!.id).toBe("claude-code");
+    expect(claude?.id).toBe("claude-code");
   });
 
   it("resolves aliases", () => {
@@ -95,25 +95,26 @@ describe("Provider Registry", () => {
   });
 
   it("resolves platform-specific paths", () => {
-    const claude = getProvider("claude-code")!;
-    expect(claude.pathGlobal).not.toContain("$HOME");
-    expect(claude.configPathGlobal).not.toContain("$HOME");
-    expect(claude.pathSkills).not.toContain("$HOME");
+    const claude = getProvider("claude-code");
+    expect(claude).toBeDefined();
+    expect(claude?.pathGlobal).not.toContain("$HOME");
+    expect(claude?.configPathGlobal).not.toContain("$HOME");
+    expect(claude?.pathSkills).not.toContain("$HOME");
   });
 
   it("has correct config keys per provider", () => {
-    expect(getProvider("claude-code")!.configKey).toBe("mcpServers");
-    expect(getProvider("codex")!.configKey).toBe("mcp_servers");
-    expect(getProvider("goose")!.configKey).toBe("extensions");
-    expect(getProvider("opencode")!.configKey).toBe("mcp");
-    expect(getProvider("vscode")!.configKey).toBe("servers");
-    expect(getProvider("zed")!.configKey).toBe("context_servers");
+    expect(getProvider("claude-code")?.configKey).toBe("mcpServers");
+    expect(getProvider("codex")?.configKey).toBe("mcp_servers");
+    expect(getProvider("goose")?.configKey).toBe("extensions");
+    expect(getProvider("opencode")?.configKey).toBe("mcp");
+    expect(getProvider("vscode")?.configKey).toBe("servers");
+    expect(getProvider("zed")?.configKey).toBe("context_servers");
   });
 
   it("has correct config formats per provider", () => {
-    expect(getProvider("claude-code")!.configFormat).toBe("json");
-    expect(getProvider("goose")!.configFormat).toBe("yaml");
-    expect(getProvider("codex")!.configFormat).toBe("toml");
-    expect(getProvider("zed")!.configFormat).toBe("jsonc");
+    expect(getProvider("claude-code")?.configFormat).toBe("json");
+    expect(getProvider("goose")?.configFormat).toBe("yaml");
+    expect(getProvider("codex")?.configFormat).toBe("toml");
+    expect(getProvider("zed")?.configFormat).toBe("jsonc");
   });
 });


### PR DESCRIPTION
## Summary
- clear the remaining Biome lint warnings across commands, core modules, and tests so CI lint exits cleanly
- remove fragile non-null assertions and add explicit guards/fallbacks in parser, installer, formatter, and registry code paths
- fix the audit token-smuggling regex to avoid misleading character class behavior and keep security scanning valid

## Validation
- npm run lint
- npm run typecheck
- npm test