### PR TITLE
fix: protocol path discovery in buildLibraryFromFiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-02-24
+
+### Fixed
+- **Protocol path discovery**: `buildLibraryFromFiles()` now checks root `protocols/` directory first, falling back to `skills/protocols/` — fixes discovery for libraries like ct-skills that place protocols at root level
+- Bumped `@cleocode/lafs-protocol` to ^1.3.2
+
+### Added
+- Test cases for root-level protocol discovery, fallback path, and precedence when both locations exist
+
 ## [1.1.0] - 2026-02-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
-        "@cleocode/lafs-protocol": "^1.2.3",
+        "@cleocode/lafs-protocol": "^1.3.2",
         "@iarna/toml": "^2.2.5",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@cleocode/lafs-protocol": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@cleocode/lafs-protocol/-/lafs-protocol-1.2.3.tgz",
-      "integrity": "sha512-8ZR7LZD8NAgpVqVW7+xz1pwA26pG9mXfOYZ3Q1PxJzV9f3O2UMnJ/9UxV8i885RdP61M191aJwUzz1oAwUktxw==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@cleocode/lafs-protocol/-/lafs-protocol-1.3.2.tgz",
+      "integrity": "sha512-HlRuWoSB7IQtqbMzxz9XohhC5FEsWweOSHyyLti5GVeQxoF1FNN4kwrC17VNTxlIfmEzy6vqZV7pZqlzf0uv5w==",
       "license": "MIT",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {
@@ -56,7 +56,7 @@
     "url": "https://github.com/kryptobaseddev/caamp/issues"
   },
   "dependencies": {
-    "@cleocode/lafs-protocol": "^1.2.3",
+    "@cleocode/lafs-protocol": "^1.3.2",
     "@iarna/toml": "^2.2.5",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",

--- a/src/core/skills/library-loader.ts
+++ b/src/core/skills/library-loader.ts
@@ -80,7 +80,7 @@ export function loadLibraryFromModule(root: string): SkillLibrary {
  * - `profiles/*.json` for profile definitions
  * - `skills/<name>/SKILL.md` for skill content
  * - `skills/_shared/*.md` for shared resources
- * - `skills/protocols/*.md` for protocol files
+ * - `protocols/*.md` or `skills/protocols/*.md` for protocol files
  *
  * @param root - Absolute path to the library root directory
  * @returns A SkillLibrary instance backed by filesystem reads
@@ -260,12 +260,18 @@ export function buildLibraryFromFiles(root: string): SkillLibrary {
     },
 
     listProtocols(): string[] {
+      // Check root protocols/ first (ct-skills layout), fall back to skills/protocols/
+      const rootProtocols = discoverFiles(join(root, "protocols"), ".md");
+      if (rootProtocols.length > 0) return rootProtocols;
       return discoverFiles(join(root, "skills", "protocols"), ".md");
     },
 
     getProtocolPath(name: string): string | undefined {
-      const protocolPath = join(root, "skills", "protocols", `${name}.md`);
-      return existsSync(protocolPath) ? protocolPath : undefined;
+      // Check root protocols/ first, fall back to skills/protocols/
+      const rootPath = join(root, "protocols", `${name}.md`);
+      if (existsSync(rootPath)) return rootPath;
+      const skillsPath = join(root, "skills", "protocols", `${name}.md`);
+      return existsSync(skillsPath) ? skillsPath : undefined;
     },
 
     readProtocol(name: string): string | undefined {

--- a/tests/unit/skill-library.test.ts
+++ b/tests/unit/skill-library.test.ts
@@ -311,6 +311,111 @@ describe("SkillLibrary via buildLibraryFromFiles", () => {
   });
 });
 
+describe("SkillLibrary protocol path discovery", () => {
+  let fixtureRoot: string;
+
+  afterEach(() => {
+    if (existsSync(fixtureRoot)) {
+      rmSync(fixtureRoot, { recursive: true, force: true });
+    }
+  });
+
+  it("discovers protocols at root protocols/ directory", () => {
+    fixtureRoot = join(tmpdir(), `caamp-test-root-protocols-${Date.now()}`);
+    mkdirSync(fixtureRoot, { recursive: true });
+
+    // Minimal skills.json
+    writeFileSync(
+      join(fixtureRoot, "skills.json"),
+      JSON.stringify({ version: "1.0.0", skills: [] }),
+    );
+
+    // Protocols at root level (ct-skills layout)
+    mkdirSync(join(fixtureRoot, "protocols"), { recursive: true });
+    writeFileSync(
+      join(fixtureRoot, "protocols", "research.md"),
+      "# Research Protocol",
+    );
+    writeFileSync(
+      join(fixtureRoot, "protocols", "implementation.md"),
+      "# Implementation Protocol",
+    );
+
+    const library = buildLibraryFromFiles(fixtureRoot);
+
+    const protocols = library.listProtocols();
+    expect(protocols).toContain("research");
+    expect(protocols).toContain("implementation");
+    expect(protocols).toHaveLength(2);
+
+    const path = library.getProtocolPath("research");
+    expect(path).toBeDefined();
+    expect(path).toContain(join("protocols", "research.md"));
+    expect(existsSync(path!)).toBe(true);
+
+    const content = library.readProtocol("research");
+    expect(content).toContain("# Research Protocol");
+  });
+
+  it("falls back to skills/protocols/ when root protocols/ is absent", () => {
+    fixtureRoot = join(tmpdir(), `caamp-test-fallback-protocols-${Date.now()}`);
+    mkdirSync(fixtureRoot, { recursive: true });
+
+    writeFileSync(
+      join(fixtureRoot, "skills.json"),
+      JSON.stringify({ version: "1.0.0", skills: [] }),
+    );
+
+    // Protocols under skills/ (legacy layout)
+    mkdirSync(join(fixtureRoot, "skills", "protocols"), { recursive: true });
+    writeFileSync(
+      join(fixtureRoot, "skills", "protocols", "consensus.md"),
+      "# Consensus Protocol",
+    );
+
+    const library = buildLibraryFromFiles(fixtureRoot);
+
+    const protocols = library.listProtocols();
+    expect(protocols).toContain("consensus");
+    expect(protocols).toHaveLength(1);
+
+    const path = library.getProtocolPath("consensus");
+    expect(path).toBeDefined();
+    expect(path).toContain(join("skills", "protocols", "consensus.md"));
+  });
+
+  it("prefers root protocols/ over skills/protocols/ when both exist", () => {
+    fixtureRoot = join(tmpdir(), `caamp-test-prefer-root-${Date.now()}`);
+    mkdirSync(fixtureRoot, { recursive: true });
+
+    writeFileSync(
+      join(fixtureRoot, "skills.json"),
+      JSON.stringify({ version: "1.0.0", skills: [] }),
+    );
+
+    // Both locations exist
+    mkdirSync(join(fixtureRoot, "protocols"), { recursive: true });
+    writeFileSync(join(fixtureRoot, "protocols", "research.md"), "# Root Research");
+
+    mkdirSync(join(fixtureRoot, "skills", "protocols"), { recursive: true });
+    writeFileSync(join(fixtureRoot, "skills", "protocols", "research.md"), "# Skills Research");
+
+    const library = buildLibraryFromFiles(fixtureRoot);
+
+    // listProtocols should return from root
+    const protocols = library.listProtocols();
+    expect(protocols).toContain("research");
+
+    // getProtocolPath should prefer root
+    const path = library.getProtocolPath("research");
+    expect(path).toContain(join(fixtureRoot, "protocols", "research.md"));
+
+    // Content should be from root
+    const content = library.readProtocol("research");
+    expect(content).toContain("# Root Research");
+  });
+});
+
 describe("buildLibraryFromFiles error cases", () => {
   it("throws when skills.json is missing", () => {
     const noSkillsDir = join(tmpdir(), `caamp-no-skills-${Date.now()}`);


### PR DESCRIPTION
## Summary
- `listProtocols()` and `getProtocolPath()` in `buildLibraryFromFiles()` now check root `protocols/` directory first, falling back to `skills/protocols/`
- Fixes protocol discovery for libraries like ct-skills that place protocols at root level
- Bumps `@cleocode/lafs-protocol` to ^1.3.2
- Version bump to 1.1.1

## Test plan
- [x] New test: discovers protocols at root `protocols/` directory
- [x] New test: falls back to `skills/protocols/` when root is absent
- [x] New test: prefers root `protocols/` over `skills/protocols/` when both exist
- [x] All 1235 existing tests pass
- [x] `tsc --noEmit` clean
- [x] `tsup` build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)