### PR TITLE
chore(deps): bump lafs-protocol to ^1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-02-24
+
+### Changed
+- Bump `@cleocode/lafs-protocol` from ^1.3.2 to ^1.4.1 (health checks, circuit breaker, graceful shutdown, A2A transport mapping)
+
 ## [1.1.2] - 2026-02-24
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.1.2",
       "license": "MIT",
       "dependencies": {
-        "@cleocode/lafs-protocol": "^1.3.2",
+        "@cleocode/lafs-protocol": "^1.4.1",
         "@iarna/toml": "^2.2.5",
         "commander": "^14.0.0",
         "gray-matter": "^4.0.3",
@@ -302,9 +302,9 @@
       }
     },
     "node_modules/@cleocode/lafs-protocol": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@cleocode/lafs-protocol/-/lafs-protocol-1.3.2.tgz",
-      "integrity": "sha512-HlRuWoSB7IQtqbMzxz9XohhC5FEsWweOSHyyLti5GVeQxoF1FNN4kwrC17VNTxlIfmEzy6vqZV7pZqlzf0uv5w==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@cleocode/lafs-protocol/-/lafs-protocol-1.4.1.tgz",
+      "integrity": "sha512-A4ZRpZpTuVzfXhsOOXs7J0+mDJsqa0OerQIEA/HYW4FiiJLkQAn4XQfegfg34mknUADDMI7lBX1Of/Rftu4YQA==",
       "license": "MIT",
       "dependencies": {
         "@a2a-js/sdk": "^0.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cleocode/caamp",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "Central AI Agent Managed Packages - unified provider registry and package manager for AI coding agents",
   "type": "module",
   "bin": {
@@ -56,7 +56,7 @@
     "url": "https://github.com/kryptobaseddev/caamp/issues"
   },
   "dependencies": {
-    "@cleocode/lafs-protocol": "^1.3.2",
+    "@cleocode/lafs-protocol": "^1.4.1",
     "@iarna/toml": "^2.2.5",
     "commander": "^14.0.0",
     "gray-matter": "^4.0.3",


### PR DESCRIPTION
## Summary
- Bump `@cleocode/lafs-protocol` from ^1.3.2 to ^1.4.1
- Version bump to 1.1.3

LAFS 1.4.1 adds:
- Health check middleware (liveness/readiness probes)
- Circuit breaker pattern for resilient service calls
- Graceful shutdown module
- A2A transport mapping conformance checks

## Test plan
- [x] `tsc --noEmit` clean
- [x] `tsup` build succeeds
- [x] 1235/1235 tests pass (59 test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)